### PR TITLE
Fix README badges to use systemshift repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Memex - Personal Knowledge Graph
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/aviaryan/memex)](https://goreportcard.com/report/github.com/aviaryan/memex)
+[![Go Report Card](https://goreportcard.com/badge/github.com/systemshift/memex)](https://goreportcard.com/report/github.com/systemshift/memex)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](LICENSE)
-[![GitHub release](https://img.shields.io/github/v/release/aviaryan/memex)](https://github.com/aviaryan/memex/releases)
+[![GitHub release](https://img.shields.io/github/v/release/systemshift/memex)](https://github.com/systemshift/memex/releases)
 
 Memex is a graph-oriented data management tool.
 


### PR DESCRIPTION
## Summary
- update badge URLs to use the current `systemshift/memex` repository
- ensure release link uses the same repository path

## Testing
- `go test ./...` *(fails: connect: no route to host)*